### PR TITLE
chore(deps): bump pingora-gateway version to 0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1428,7 +1428,7 @@ checksum = "8e39924926e498ddb0e64a642b6c5df56627afc0989b0f7be197eb096f998f0f"
 
 [[package]]
 name = "pingora-gateway"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pingora-gateway"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Richard Hao <richard@0xdev.dev>"]
 license = "MIT"
 edition = "2021"


### PR DESCRIPTION
Updates the version of pingora-gateway from 0.1.3 to 0.1.4 in both Cargo.toml and Cargo.lock files.